### PR TITLE
Cirrus CI: proof of concept

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,32 @@
+env:
+  CIRRUS_WORKING_DIR: /checkout
+  SRC: /checkout
+  CIRRUS_CLONE_DEPTH: 50
+  CARGO_HOME: /cargo
+  SCCACHE_DIR: /sccache
+
+timeout_in: 120m
+
+task:
+  env:
+    CPU: 8
+    MEMORY: 24G
+    DOCKER_CONTEXT: src/ci/docker
+    matrix:
+      - IMAGE: x86_64-gnu-llvm-6.0
+        RUST_BACKTRACE: 1
+      - IMAGE: dist-x86_64-linux
+        DEPLOY: 1
+      - IMAGE: dist-x86_64-linux
+        DEPLOY_ALT: 1
+  container:
+    dockerfile: src/ci/docker/$IMAGE/Dockerfile
+    cpu: $CPU
+    memory: $MEMORY
+  init_script:
+    - mkdir -p $HOME/rustsrc
+    - ./src/ci/init_repo.sh . $HOME/rustsrc
+  run_script:
+    - mkdir -p obj
+    - cd obj
+    - /checkout/src/ci/run.sh

--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -67,7 +67,7 @@ for i in ${!modules[@]}; do
 done
 retry sh -c "git submodule deinit -f $use_git && \
     git submodule sync && \
-    git submodule update -j 16 --init --recursive $use_git"
+    git submodule update --init --recursive $use_git"
 wait
 travis_fold end init_repo
 travis_time_finish


### PR DESCRIPTION
In the lights of the recent [post about Rust looking for alternative CIs](https://internals.rust-lang.org/t/which-ci-platform-should-rust-use/9322/6), I've made a quick attempt to migrate to Cirrus CI. 

Thankfully Rust's CI build is already Dockerized and Cirrus CI supports [Dockerfile as an environment for tasks](https://cirrus-ci.org/guide/docker-builder/#dockerfile-as-a-ci-environment). So there is no need to do the Docker image building and caching like in the current setup. Cirrus CI does it automatically based on Dockerfile content.

As you can see the config is small and pretty simple and Cirrus CI performs quite well since it uses 8 CPU and 24G of memory.

I also tried to run with less CPU and memory and noticed that more resources don't make the build linearly faster. I assume there is a great potential in optimizing the build itself to use all available CPUs.

@pietroalbini PTAL and let me know if you'd like to evaluate something else.